### PR TITLE
Even if it's local, still make sure it's not a 404

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,8 +23,6 @@ function createActiveXHR() {
     } catch( e ) {}
 }
 
-var isLocal = window.location.protocol === "file:";
-
 // Create the request object
 var createXHR = window.ActiveXObject ?
     /* Microsoft failed to properly
@@ -34,7 +32,7 @@ var createXHR = window.ActiveXObject ?
      * we need a fallback.
      */
     function() {
-    return !isLocal && createStandardXHR() || createActiveXHR();
+    return createStandardXHR() || createActiveXHR();
 } :
     // For all other browsers, use the standard XMLHttpRequest object
     createStandardXHR;
@@ -76,7 +74,7 @@ JSZipUtils.getBinaryContent = function(path, callback) {
             var file, err;
             // use `xhr` and not `this`... thanks IE
             if (xhr.readyState === 4) {
-                if (xhr.status === 200 || (isLocal && xhr.status !== 404)) {
+                if (xhr.status === 200 || xhr.status === 0) {
                     file = null;
                     err = null;
                     try {


### PR DESCRIPTION
I've found that when I try to get a zip file from the local network, that this section of code is treating all requests as good, even if I get a 404.  I'm not sure of the reasoning behind the isLocal variable, but I think at least making sure the status isn't 404 is a good thing.  Perhaps you could comment on why we can allow something other than 200 for a local request?
