### PR TITLE
JSZipUtils.xhr, support node.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var JSZipUtils = {};
+let JSZipUtils = {};
 // just use the responseText with xhr1, response with xhr2.
 // The transformation doesn't throw away high-order byte (with responseText)
 // because JSZip handles that case. If not used with JSZip, you may need to
@@ -23,21 +23,16 @@ function createActiveXHR() {
     } catch( e ) {}
 }
 
-// Create the request object
-var createXHR = (typeof window !== "undefined" && window.ActiveXObject) ?
-    /* Microsoft failed to properly
-     * implement the XMLHttpRequest in IE7 (can't request local files),
-     * so we use the ActiveXObject when it is available
-     * Additionally XMLHttpRequest can be disabled in IE7/IE8 so
-     * we need a fallback.
-     */
-    function() {
-    return createStandardXHR() || createActiveXHR();
-} :
-    // For all other browsers, use the standard XMLHttpRequest object
-    createStandardXHR;
+JSZipUtils.xhr = null;
 
+function createXHR()
+{
+    if (JSZipUtils.xhr || window.XMLHttpRequest) {
+		return new (JSZipUtils.xhr || window.XMLHttpRequest);
+    }
 
+    return createActiveXHR();
+}
 
 JSZipUtils.getBinaryContent = function(path, callback) {
     /*
@@ -56,7 +51,7 @@ JSZipUtils.getBinaryContent = function(path, callback) {
      */
     try {
 
-        var xhr = createXHR();
+        let xhr = createXHR();
 
         xhr.open('GET', path, true);
 
@@ -71,7 +66,7 @@ JSZipUtils.getBinaryContent = function(path, callback) {
         }
 
         xhr.onreadystatechange = function(evt) {
-            var file, err;
+			let file, err;
             // use `xhr` and not `this`... thanks IE
             if (xhr.readyState === 4) {
                 if (xhr.status === 200 || xhr.status === 0) {
@@ -80,7 +75,7 @@ JSZipUtils.getBinaryContent = function(path, callback) {
                     try {
                         file = JSZipUtils._getBinaryFromXHR(xhr);
                     } catch(e) {
-                        err = new Error(e);
+                        err = e;
                     }
                     callback(err, file);
                 } else {
@@ -92,7 +87,7 @@ JSZipUtils.getBinaryContent = function(path, callback) {
         xhr.send();
 
     } catch (e) {
-        callback(new Error(e), null);
+        callback(e, null);
     }
 };
 


### PR DESCRIPTION
allow use `JSZipUtils.xhr = JSZipUtils.xhr || require("xmlhttprequest-ssl").XMLHttpRequest`